### PR TITLE
pro edition only settings

### DIFF
--- a/src/templates/settings/_core.twig
+++ b/src/templates/settings/_core.twig
@@ -31,6 +31,8 @@
 
     {{ csrfInput() }}
 
+    {% if CraftEdition == CraftPro %}
+
     <h3>User Account Creation</h3>
 
     {% set enabled = 0 %}
@@ -48,6 +50,8 @@
         name: 'settings[core][create][enabled]',
         on: enabled
     }) }}
+
+    {% endif %}
 
     <h3>User Account Login</h3>
 


### PR DESCRIPTION
drip account creation settings that require craft pro will not be shown for solo edition